### PR TITLE
Test getAllCom

### DIFF
--- a/R/getAllCom.R
+++ b/R/getAllCom.R
@@ -51,37 +51,38 @@ getAllCom <- function(X) {
     ComtyID[lastCOM[[i]]] <- i
   }
   
-  # Merge single-feature communities into nearest correlated community
-  cmty.sizeis1 <- which(lengths(lastCOM) == 1)
-  if (length(cmty.sizeis1) > 0) {
-    for (i in cmty.sizeis1) {
-      S1.metID <- lastCOM[[i]]
-      allCorwithS1 <- G[, S1.metID]
-      allCorwithS1[S1.metID] <- 0  # Ignore self-correlation
-      Maxcor.metID <- which.max(allCorwithS1)
+  if (length(lastCOM) > 1) { # Make sure more than one community exists
+    # Merge single-feature communities into nearest correlated community
+    cmty.sizeis1 <- which(lengths(lastCOM) == 1)
+    if (length(cmty.sizeis1) > 0) {
+      for (i in cmty.sizeis1) {
+        S1.metID <- lastCOM[[i]]
+        allCorwithS1 <- G[, S1.metID]
+        allCorwithS1[S1.metID] <- 0  # Ignore self-correlation
+        Maxcor.metID <- which.max(allCorwithS1)
       
-      mergeCmty <- ComtyID[Maxcor.metID]
-      lastCOM[[mergeCmty]] <- c(lastCOM[[mergeCmty]], S1.metID)
-      ComtyID[S1.metID] <- mergeCmty
+        mergeCmty <- ComtyID[Maxcor.metID]
+        lastCOM[[mergeCmty]] <- c(lastCOM[[mergeCmty]], S1.metID)
+        ComtyID[S1.metID] <- mergeCmty
+      }
+      lastCOM <- lastCOM[-cmty.sizeis1]
     }
-    lastCOM <- lastCOM[-cmty.sizeis1]
-  }
   
-  # Merge two-feature communities into nearest correlated community
-  cmty.sizeis2 <- which(lengths(lastCOM) == 2)
-  if (length(cmty.sizeis2) > 0) {
-    for (i in cmty.sizeis2) {
-      S2.metID <- lastCOM[[i]]
-      allCorwithS2 <- G[, S2.metID]
-      allCorwithS2[S2.metID, ] <- 0  # Ignore self-correlation
-      Maxcor.metID <- which(allCorwithS2 == max(allCorwithS2), arr.ind = TRUE)[1]
+    # Merge two-feature communities into nearest correlated community
+    cmty.sizeis2 <- which(lengths(lastCOM) == 2)
+    if (length(cmty.sizeis2) > 0) {
+      for (i in cmty.sizeis2) {
+        S2.metID <- lastCOM[[i]]
+        allCorwithS2 <- G[, S2.metID]
+        allCorwithS2[S2.metID, ] <- 0  # Ignore self-correlation
+        Maxcor.metID <- which(allCorwithS2 == max(allCorwithS2), arr.ind = TRUE)[1]
       
-      mergeCmty <- ComtyID[Maxcor.metID]
-      lastCOM[[mergeCmty]] <- c(lastCOM[[mergeCmty]], S2.metID)
+        mergeCmty <- ComtyID[Maxcor.metID]
+        lastCOM[[mergeCmty]] <- c(lastCOM[[mergeCmty]], S2.metID)
+      }
+      lastCOM <- lastCOM[-cmty.sizeis2]
     }
-    lastCOM <- lastCOM[-cmty.sizeis2]
   }
-  
   return(lastCOM)
 }
 

--- a/R/getAllCom.R
+++ b/R/getAllCom.R
@@ -106,25 +106,26 @@ ComtyDet <- function(G, InputCOM, minCOMSize){
   InputCOM <- InputCOM[!ii]
   
   # Community detection
-  for (i in c(1: length(InputCOM))) {
-    InputG <- abs(G[InputCOM[[i]], InputCOM[[i]]])
-    InputG <- InputG - diag(diag(InputG))
-    Graph.InputG <- graph_from_adjacency_matrix(InputG, 
-                                                weighted = TRUE, 
-                                                mode = "undirected")
-    COMTY <- cluster_louvain(Graph.InputG)
-    cmty.id <- membership(COMTY)
-    cmty.size <- as.vector(sizes(COMTY))
-    NumComty <- length(cmty.size)
+  if (length(InputCOM) > 0) { # skip this loop if all communities are small.
+    for (i in seq_len(length(InputCOM))) {
+      InputG <- abs(G[InputCOM[[i]], InputCOM[[i]]])
+      InputG <- InputG - diag(diag(InputG))
+      Graph.InputG <- graph_from_adjacency_matrix(InputG, 
+                                                  weighted = TRUE, 
+                                                  mode = "undirected")
+      COMTY <- cluster_louvain(Graph.InputG)
+      cmty.id <- membership(COMTY)
+      cmty.size <- as.vector(sizes(COMTY))
+      NumComty <- length(cmty.size)
     
-    for (n in c(1: NumComty)) {
-      Node.Idx <- (cmty.id == n)
-      Node.InitID <- InputCOM[[i]][Node.Idx]
-      k <- k + 1
-      nextCOM[[k]] <- Node.InitID
+      for (n in c(1: NumComty)) {
+        Node.Idx <- (cmty.id == n)
+        Node.InitID <- InputCOM[[i]][Node.Idx]
+        k <- k + 1
+        nextCOM[[k]] <- Node.InitID
+      }
     }
   }
-  
   return(nextCOM)
 }
 

--- a/tests/testthat/test-ComtyDet.R
+++ b/tests/testthat/test-ComtyDet.R
@@ -1,0 +1,41 @@
+library(testthat)
+library(CordBat)
+
+test_that("ComtyDet leaves small communities unchanged", {
+  # G = 4×4 identity => no edges, everything is size <= 2
+  G <- diag(1, 4)
+  InputCOM <- list(1:2, 3:4)
+  out <- CordBat:::ComtyDet(G, InputCOM, minCOMSize = 2)
+  expect_equal(out, InputCOM)
+})
+
+test_that("ComtyDet splits a clear two-block structure", {
+  # two perfect blocks and no cross-block edges
+  G <- matrix(0,4,4)
+  G[1,2] <- G[2,1] <- 1
+  G[3,4] <- G[4,3] <- 1
+  
+  InputCOM <- list(1:4)
+  out <- CordBat:::ComtyDet(G, InputCOM, minCOMSize = 1)
+  
+  # we should get exactly 2 communities
+  expect_length(out, 2)
+  
+  # and one must be {1,2}, the other {3,4} (in any order)
+  comm_sets <- lapply(out, sort)
+  expect_true(any(identical(comm_sets[[1]], c(1L,2L)),
+                  identical(comm_sets[[2]], c(1L,2L))))
+  expect_true(any(identical(comm_sets[[1]], c(3L,4L)),
+                  identical(comm_sets[[2]], c(3L,4L))))
+})
+
+test_that("ComtyDet output covers all input indices exactly once", {
+  G <- diag(1, 5)   # trivial graph
+  InputCOM <- list(1:3, 4:5)
+  out <- CordBat:::ComtyDet(G, InputCOM, minCOMSize = 2)
+  
+  all_in <- sort(unlist(InputCOM))
+  all_out <- sort(unlist(out))
+  expect_equal(all_out, all_in)
+  expect_length(all_out, length(unique(all_out)))
+})

--- a/tests/testthat/test-getAllCom.R
+++ b/tests/testthat/test-getAllCom.R
@@ -1,0 +1,43 @@
+library(testthat)
+library(CordBat)
+
+test_that("getAllCom on single-feature returns list(1)", {
+  X <- matrix(rnorm(10), nrow=10, ncol=1)
+  comms <- CordBat:::getAllCom(X)
+  expect_equal(comms, list(1L))
+})
+
+test_that("getAllCom on identical columns returns one group", {
+  X <- matrix(rep(1:10, 3), nrow=10, ncol=3)  # 3 identical cols
+  comms <- CordBat:::getAllCom(X)
+  expect_length(comms, 1)
+  expect_equal(sort(comms[[1]]), 1:3)
+})
+
+test_that("getAllCom on independent noise covers all features in small groups", {
+  set.seed(42)
+  X <- matrix(rnorm(100), nrow = 10, ncol = 10)
+  comms <- CordBat:::getAllCom(X)
+  # coverage
+  expect_equal(sort(unlist(comms)), 1:10)
+  # no group too large
+  maxCOMSize <- min(round(nrow(X) * 0.4), 50)
+  expect_true(all(lengths(comms) <= maxCOMSize))
+})
+
+test_that("getAllCom assigns every feature exactly once", {
+  set.seed(2025)
+  X <- matrix(rnorm(60), nrow=10, ncol=6)
+  comms <- CordBat:::getAllCom(X)
+  all_feats <- sort(unlist(comms))
+  expect_equal(all_feats, seq_len(ncol(X)))
+  expect_length(all_feats, length(unique(all_feats)))
+})
+
+test_that("getAllCom is reproducible (identical runs)", {
+  set.seed(99)
+  X <- matrix(rnorm(200), nrow=20, ncol=10)
+  c1 <- CordBat:::getAllCom(X)
+  c2 <- CordBat:::getAllCom(X)
+  expect_identical(c1, c2)
+})


### PR DESCRIPTION
1. Small modifications made to ComtyDet and getAllCom.
* Updated ComtyDet function to not crash when all communities are <= minCOMSize.
* Updated getAllCom function to only merge singleton and 2 feature communities if there is more than 1 community.

2. Unit tests written for ComtyDet and getAllCom.